### PR TITLE
Prater: list block root with state-root update, and validators root

### DIFF
--- a/shared/prater/README.md
+++ b/shared/prater/README.md
@@ -5,7 +5,10 @@ Prater Testnet (v1.0.1)
 - Genesis Fork Version: `0x00001020` (Prater area code, Vienna)
 - Fork Digest: `0x79df0428` (`0xe4be9393` pre-genesis fork digest)
 - Initial State Root: `0x895390e92edc03df7096e9f51e51896e8dbe6e7e838180dadbfd869fdd77a659`
-- Genesis Block Root: `0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4`
+- Genesis Block Root:
+	- Without state root update: `0xeade62f0457b2fdf48e7d3fc4b60736688286be7c7a3ac4c9a16a5e0600bd9e4`
+	- With state root update: `0x8c0ebce425ca04612f8a4c9b3d9b339121a62a8fe2baf8ff2c6f77b81194ee87`
+- Genesis Validators Root: `0x043db0d9a83813551ee2f33450d23797757d430911a9320530ad8a0eabc43efb`
 - Deposit Contract: `0xff50ed3d0ec03aC01D4C79aAd74928BFF48a7b2b` (Goerli Testnet)
 	- Mainnet: [`DoNotSendFundsHere`](https://etherscan.io/address/0xff50ed3d0ec03ac01d4c79aad74928bff48a7b2b#code)
 	- Goerli: [`DepositContract`](https://goerli.etherscan.io/address/0xff50ed3d0ec03ac01d4c79aad74928bff48a7b2b#code)


### PR DESCRIPTION
@paulhauner noticed that the block root did not match with their client. And then others had the same. This was not due to a bug, but due to a different interpretation: the root of the `latest_header` without state-root update (i.e. zero state root) was listed, instead of the one with update state root (like every real block).

This PR lists both block roots, and adds the genesis validators root for completeness.

Computed with spec, using update genesis details script [here](https://github.com/protolambda/eth2-testnet-genesis/blob/master/compute_genesis_details.py)
